### PR TITLE
CORS Support doc and config

### DIFF
--- a/source/apollo-client/index.md
+++ b/source/apollo-client/index.md
@@ -66,7 +66,7 @@ const client = new ApolloClient({
 
 <h4 id="corsSupport" title="cors support">CORS support</h3>
 
-Please reference the apollo-server/tools.md for informaiton on how to configure the apollo-server to correctly mitigate CORS issues when the apollo-client and apollo-server are running on seperate instances.
+When attempting to setup an apollo-server and client application running on different instances, you will find http-405 errors thrown by the client. This happens when recieving the response from the server which is denying the request because of CORS. The client is working as designed. CORS support should be enabled in the apollo-server instance. Howto can be found in the [apollo-server/tools.md](/source/apollo-server/tools.md). This was encountered using the meteor-stater-kit and was confirmed from others running the apollo-server with express in node.
 
 <h3 id="store-rehydration" title="Loading Intial Data from Server">Loading Intial Data from Server</h3>
 

--- a/source/apollo-client/index.md
+++ b/source/apollo-client/index.md
@@ -64,33 +64,9 @@ const client = new ApolloClient({
 });
 ```
 
-To automatically send cookies for the current domain (same server-client environment), the credentials option must be provided,
+<h4 id="corsSupport" title="cors support">CORS support</h3>
 
-```js
-import ApolloClient, { createNetworkInterface } from 'apollo-client';
-
-const networkInterface = createNetworkInterface('/graphql', {
-  credentials: 'same-origin',
-  headers: {
-    'X-CSRF-Token': "xyz", // Rails or Phoenix framework
-    token: 'supersecret' // Custom auth token
-  }
-});
-
-const client = new ApolloClient({ networkInterface });
-```
-
-Use the include value to send cookies in a cross-origin resource sharing (CORS) request.
-
-```js
-const networkInterface = createNetworkInterface('/graphql', {
-  credentials: 'include',
-  headers: {
-    'X-CSRF-Token': "xyz",
-    token: 'supersecret'
-  }
-});
-```
+Please reference the apollo-server/tools.md for informaiton on how to configure the apollo-server to correctly mitigate CORS issues when the apollo-client and apollo-server are running on seperate instances.
 
 <h3 id="store-rehydration" title="Loading Intial Data from Server">Loading Intial Data from Server</h3>
 

--- a/source/apollo-server/tools.md
+++ b/source/apollo-server/tools.md
@@ -29,7 +29,7 @@ var app = express().use('*', cors());;
 ```
 Ensure you have npm installed cors. The * value allows access from any third-party site. It should probably be updated to reflect your specific environment. Additional information https://github.com/expressjs/cors
 
-The information contained in the apolloClient re: CORS configuration did not have effect on the server.
+The information contained in the apolloClient re: CORS configuration did not effect on the server.
 
 **Function signature**
 

--- a/source/apollo-server/tools.md
+++ b/source/apollo-server/tools.md
@@ -18,6 +18,19 @@ var app = express();
 app.use('/graphql', apolloServer({ schema: typeDefinitionArray, graphiql: true }));
 ```
 
+An issue was discovered re: CORS when using the apolloClient to connect to an apolloServer running on a different instance. 
+To account for this CORS support must be configured in the express app.
+
+```
+import { apolloServer } from 'graphql-tools';
+import cors from 'cors';
+
+var app = express().use('*', cors());;
+```
+Ensure you have npm installed cors. The * value allows access from any third-party site. It should probably be updated to reflect your specific environment. Additional information https://github.com/expressjs/cors
+
+The information contained in the apolloClient re: CORS configuration did not have effect on the server.
+
 **Function signature**
 
 ```

--- a/source/apollo-server/tools.md
+++ b/source/apollo-server/tools.md
@@ -21,7 +21,7 @@ app.use('/graphql', apolloServer({ schema: typeDefinitionArray, graphiql: true }
 <h4 id="corsSupport" title="cors support">CORS support</h3>
 
 An issue was discovered re: CORS when using the apolloClient to connect to an apolloServer running on a different instance. 
-To account for this CORS support must be configured in the express app.
+To account for this CORS support must be configured in the express app. [CORS](https://github.com/expressjs/cors) is a node.js package for providing a Connect/Express middleware that can be used to enable CORS with various options. 
 
 ```
 import { apolloServer } from 'graphql-tools';
@@ -29,7 +29,8 @@ import cors from 'cors';
 
 var app = express().use('*', cors());;
 ```
-Ensure you have npm installed cors. The * value allows access from any third-party site. It should probably be updated to reflect your specific environment. Additional information https://github.com/expressjs/cors
+
+Ensure you have npm installed cors. The * value allows access from any third-party site. It should probably be updated to reflect your specific environment. Simple usage details to [Enable All CORS Requests](https://github.com/expressjs/cors#simple-usage-enable-all-cors-requests) More complex configuration options are available including the ability to [Enable CORS for a Single Route](https://github.com/expressjs/cors#enable-cors-for-a-single-route).
 
 The information contained in the apolloClient re: CORS configuration did not effect on the server.
 

--- a/source/apollo-server/tools.md
+++ b/source/apollo-server/tools.md
@@ -18,6 +18,8 @@ var app = express();
 app.use('/graphql', apolloServer({ schema: typeDefinitionArray, graphiql: true }));
 ```
 
+<h4 id="corsSupport" title="cors support">CORS support</h3>
+
 An issue was discovered re: CORS when using the apolloClient to connect to an apolloServer running on a different instance. 
 To account for this CORS support must be configured in the express app.
 


### PR DESCRIPTION
After splitting the apolloServer and apolloClient based on the meteor-starter kit repo I ran into CORS errors which prevented the client from accessing the apollo-server. The remedy was to configure the express engine to use the npm cors. The docs have been updated to reflect proper setup.