### PR TITLE
Recommend importing gql literal into each file

### DIFF
--- a/source/apollo-client/core.md
+++ b/source/apollo-client/core.md
@@ -20,24 +20,30 @@ const query = gql`
 `
 ```
 
-There are two ways to import and use the `gql` tag. You can either register it globally:
-
-```js
-// Register it globally
-import { registerGqlTag } from 'apollo-client/gql';
-registerGqlTag();
-
-// Now, in any part of your app you can use the gql tag
-const query = gql`...`;
-```
-
-Alternatively, you can import it in every file if you want to be more explicit:
+The `gql` tag is a function under the hood, therefore it must be imported wherever it is used:
 
 ```js
 import gql from 'apollo-client/gql';
 
 const query = gql`...`;
 ```
+
+Alternatively, if you prefer *not* to import the `gql` tag each time you use it, you can register it as a global:
+
+```js
+// In a browser
+import { registerGqlTag } from 'apollo-client/gql';
+window['gql'] = gql;
+
+// In node.js
+import { registerGqlTag } from 'apollo-client/gql';
+global['gql'] = gql;
+
+// Now, in any part of your app you can use the gql tag
+const query = gql`...`;
+```
+
+**Note:** ES6 imports are hoisted, which may mean that client code using the `gql` tag gets evaluated before the registration of the global. To avoid race conditions, it's best to just import the tag into each file that uses it.
 
 This template literal tag serves two functions:
 

--- a/source/apollo-client/core.md
+++ b/source/apollo-client/core.md
@@ -23,7 +23,7 @@ const query = gql`
 The `gql` tag is a function under the hood, therefore it must be imported wherever it is used:
 
 ```js
-import gql from 'apollo-client/gql';
+import gql from 'graphql-tag';
 
 const query = gql`...`;
 ```
@@ -32,11 +32,11 @@ Alternatively, if you prefer *not* to import the `gql` tag each time you use it,
 
 ```js
 // In a browser
-import { registerGqlTag } from 'apollo-client/gql';
+import gql from 'graphql-tag';
 window['gql'] = gql;
 
 // In node.js
-import { registerGqlTag } from 'apollo-client/gql';
+import gql from 'graphql-tag';
 global['gql'] = gql;
 
 // Now, in any part of your app you can use the gql tag


### PR DESCRIPTION
This makes a recommendation to import the `gql` tag wherever it is used, and let's people know how to manually set it as a global as they wish. The `registerGqlTag()` function may be deprecated.