### PR TITLE
Added documentation about query composition through fragments

### DIFF
--- a/source/apollo-client/core.md
+++ b/source/apollo-client/core.md
@@ -350,7 +350,8 @@ Say we need to fetch a list of authors' names in one UI component and fetch the 
 client.query({ query: gql`
   query {
     author {
-      name
+      firstName
+      lastName
     }
   }`,
 });


### PR DESCRIPTION
Added documentation about a recently-added feature in Apollo Client: doing query composition by referencing fragments. 