### PR TITLE
Fixed react.md in apollo docs.

### DIFF
--- a/source/apollo-client/react.md
+++ b/source/apollo-client/react.md
@@ -266,3 +266,4 @@ ReactDOM.render(
   </ApolloProvider>,
   root
 );
+```


### PR DESCRIPTION
Added the ``` to the bottom of the page, github renders it fine without but the docs break.