### PR TITLE
Update meteor.md

### DIFF
--- a/source/apollo-client/meteor.md
+++ b/source/apollo-client/meteor.md
@@ -10,7 +10,7 @@ To install `apollo`, run both of these commands:
 
 ```text
 meteor add apollo
-meteor npm install --save apollo-client apollo-server express
+meteor npm install --save apollo-client apollo-server express graphql
 ```
 
 ## Usage


### PR DESCRIPTION
install graphql for Meteor integration

Right now, you also have to specify `apollo-server@^0.1.1`, but I think [that will change soon](https://github.com/apollostack/meteor-integration/pull/26).