### PR TITLE
mention koa 2 in server docs

### DIFF
--- a/source/apollo-server/graphiql.md
+++ b/source/apollo-server/graphiql.md
@@ -65,9 +65,9 @@ server.register({
 ```
 
 
-<h2 id="graphiqlKoa">Using with Koa</h2>
+<h2 id="graphiqlKoa">Using with Koa 2</h2>
 
-If you are using Koa, GraphiQL can be configured as follows:
+If you are using Koa 2, GraphiQL can be configured as follows:
 
 ```js
 import { graphiqlKoa } from 'apollo-server';

--- a/source/apollo-server/setup.md
+++ b/source/apollo-server/setup.md
@@ -4,7 +4,7 @@ order: 302
 description: How to set up Apollo Server
 ---
 
-Apollo Server exports `apolloExpress`, `apolloConnect`, `ApolloHAPI` and `apolloKoa` which can be used as a drop-in to turn your Express, Connect, HAPI or Koa server into a GraphQL server.
+Apollo Server exports `apolloExpress`, `apolloConnect`, `ApolloHAPI` and `apolloKoa` which can be used as a drop-in to turn your Express, Connect, HAPI or Koa 2 server into a GraphQL server.
 
 
 <h2 id="apolloOptions">ApolloOptions</h2>
@@ -100,7 +100,7 @@ server.register({
 ```
 
 
-<h2 id="apolloKoa">Using with Koa</h2>
+<h2 id="apolloKoa">Using with Koa 2</h2>
 
 The following code snippet shows how to use Apollo Server with Koa:
 


### PR DESCRIPTION
Was pulling my hair out for half an hour because I was using koa 1.x but the middleware provided by apollo is for 2.x only.

[https://github.com/apollostack/apollo-server/issues/84](https://github.com/apollostack/apollo-server/issues/84)