### PR TITLE
Add missing compose import

### DIFF
--- a/source/apollo-client/redux.md
+++ b/source/apollo-client/redux.md
@@ -18,7 +18,7 @@ To integrate with your existing Redux store:
 Here's what it looks like all together:
 
 ```js
-import { createStore, combineReducers, applyMiddleware } from 'redux';
+import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
 import ApolloClient from 'apollo-client';
 import { todoReducer, userReducer } from './reducers';
 


### PR DESCRIPTION
# Add missing compose import

When trying out this code I noticed `compose` does not get imported anywhere. This could be confusing since there is an npm package named `compose`. I know too little of `redux` to be certain whether this npm package is used internally, but when browsing through the `apollo-client` source, I noticed the `compose` function is imported via the `redux` package.