### PR TITLE
A new GraphQL server starter-kit

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -31,6 +31,7 @@ We have put together some basic example apps using various parts of Apollo; chec
 - [Githunt - A full-stack Apollo Client and Server example app that uses React, Webpack, Babel, and Redux](https://github.com/apollostack/GitHunt)
 - [Githunt written in Angular 2](https://github.com/apollostack/GitHunt-angular2)
 - [A GraphQL server example that uses SQL, MongoDB + REST](https://github.com/apollostack/apollo-server-tutorial)
+- [A GraphQL server starter-kit](https://github.com/Quadric/perfect-graphql-starter)
 - [A simple GraphQL blog that uses Feathersjs for managing database services](https://github.com/swarthout/feathers-apollo)
 - [A fork of Facebook's F8 React Native app that uses Apollo](https://github.com/nnance/f8app-apollo)
 - [A production-ready starter-kit using React and Webpack](https://github.com/saikat/react-apollo-starter-kit)


### PR DESCRIPTION
After some thinking I realised that by helping "getting off the ground", the [apollostack/apollo-starter-kit](https://github.com/apollostack/apollo-starter-kit) repository was aiming to teach people to start with GraphQL and Apollo (which was my case, thank you!) but it was not going further. There is a gap in between "learn this technology" and "this is how you should be using it". 

I couldn't find such thing in any of the other repos of `apollostack` as well, and trying to cover this gap I created the [perfect-graphql-starter](https://github.com/Quadric/perfect-graphql-starter/). I hope someone likes it!  😄 

Could we add a link to it in docs?